### PR TITLE
feat: add basic highlighting

### DIFF
--- a/src/ansi-colored.tmLanguage.json
+++ b/src/ansi-colored.tmLanguage.json
@@ -1,0 +1,21 @@
+{
+  "name": "ANSI-Colored Text Highlighting",
+  "scopeName": "source.ansi-colored",
+  "fileTypes": ["txt", "log"],
+  "patterns": [
+    {
+      "comment": "foreground color",
+      "contentName": "constant.language",
+      "begin": "\\x1b\\[(3|9)[0-7]m",
+      "end": "\\x1b\\[39m",
+      "name": "comment"
+    },
+    {
+      "comment": "background color",
+      "contentName": "string.quoted.double",
+      "begin": "\\x1b\\[(4|10)[0-7]m",
+      "end": "\\x1b\\[49m",
+      "name": "comment"
+    }
+  ]
+}

--- a/src/package.json
+++ b/src/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ANSI-Colored TextMate bundle",
+  "contributes": {
+    "languages": [{
+      "id": "ansi-colored",
+      "extensions": [".txt", ".log"]
+    }],
+    "grammars": [{
+      "language": "ansi-colored",
+      "scopeName": "source.ansi-colored",
+      "path": "ansi-colored.tmLanguage.json"
+    }]
+  }
+}

--- a/test/example.log
+++ b/test/example.log
@@ -1,0 +1,4 @@
+Lorem ipsum [34mdolor[39m sit amet, [37mconsectetur[39m
+adipiscing elit, sed do [42meiusmod[49m tempor
+incididunt ut labore et dolore magna [47maliqua[49m.
+


### PR DESCRIPTION
Using one arbitrary name for each of [bright] foreground and [bright] background color.

Example:
![grafik](https://github.com/tim-sh/ansi-textmate/assets/108271660/631c5abc-8d67-43c0-af1b-ecf6fa96975e)
